### PR TITLE
Fix indenting of Unbound example and remove "prefetch: yes"

### DIFF
--- a/draft-wkumari-dnsop-localroot-bcp.md
+++ b/draft-wkumari-dnsop-localroot-bcp.md
@@ -523,12 +523,11 @@ The following example configuration will prefill the IANA root zone using HTTPS:
 
 ~~~
 auth-zone:
-  name: "."
-  url: "https://www.internic.net/domain/root.zone"
-  zonefile: "root.zone"
-        fallback-enabled: yes
+    name: "."
+    url: "https://www.internic.net/domain/root.zone"
+    zonefile: "root.zone"
+    fallback-enabled: yes
     for-downstream: no
     for-upstream: yes
     zonefile: "root.zone"
-  prefetch: yes
 ~~~


### PR DESCRIPTION
If "prefetch: yes" should be kept, it should be configured under the
"server:" clause, not underneath "auth-zone:"